### PR TITLE
Price update to use Updated formula over average price

### DIFF
--- a/moxie-protocol-transactional/src/utils.ts
+++ b/moxie-protocol-transactional/src/utils.ts
@@ -182,3 +182,20 @@ export function _calculateSellSideProtocolAmountAddingBackFees(protocolSellFeePc
   // moxieAmount_ = (estimatedAmount * PCT_BASE) / (PCT_BASE - totalFeePCT);
   return _buyAmount.times(PCT_BASE).div(PCT_BASE.minus(totalFeePCT))
 }
+
+export class CalculatePrice {
+  price: BigDecimal
+  priceInWei: BigDecimal
+  //Price = Reserve/TotalSupply * ReserveRatio
+  constructor(reserve: BigInt, totalSupply: BigInt, reserveRatio: BigInt) {
+    if (reserveRatio.equals(BigInt.zero())) {
+      this.price = BigDecimal.zero()
+      this.priceInWei = BigDecimal.zero()
+    } else {
+      //Converting it from 800000 to 0.8
+      let reserveRatioDecimal = reserveRatio.divDecimal(BigInt.fromI32(10).pow(6).toBigDecimal())
+      this.price = reserve.divDecimal(totalSupply.toBigDecimal().times(reserveRatioDecimal))
+      this.priceInWei = this.price.times(BigInt.fromI32(10).pow(18).toBigDecimal())
+    }
+  }
+}

--- a/moxie-protocol/src/auction.ts
+++ b/moxie-protocol/src/auction.ts
@@ -72,7 +72,8 @@ export function handleClaimedFromOrder(event: ClaimedFromOrder): void {
     log.warning("Subject amount is zero, txHash: {}", [event.transaction.hash.toHexString()])
     return
   }
-  let calculatedPrice = new CalculatePrice(protocolTokenAmount, subjectAmount)
+  let subjectToken = getOrCreateSubjectToken(subjectTokenAddress, event.block)
+  let calculatedPrice = new CalculatePrice(subjectToken.reserve, subjectToken.totalSupply, subjectToken.reserveRatio)
   // updating user's portfolio
   let portfolio = getOrCreatePortfolio(userAddress, subjectTokenAddress, event.transaction.hash, event.block)
   portfolio.buyVolume = portfolio.buyVolume.plus(protocolTokenAmount)
@@ -107,7 +108,6 @@ export function handleClaimedFromOrder(event: ClaimedFromOrder): void {
   summary.totalBuyVolume = summary.totalBuyVolume.plus(protocolTokenAmount)
   summary.save()
 
-  let subjectToken = getOrCreateSubjectToken(subjectTokenAddress, event.block)
   subjectToken.buySideVolume = subjectToken.buySideVolume.plus(protocolTokenAmount)
   subjectToken.protocolTokenInvested = subjectToken.protocolTokenInvested.plus(new BigDecimal(protocolTokenAmount))
   subjectToken.lifetimeVolume = subjectToken.lifetimeVolume.plus(protocolTokenAmount)

--- a/moxie-protocol/src/moxie-bonding-curve.ts
+++ b/moxie-protocol/src/moxie-bonding-curve.ts
@@ -163,7 +163,11 @@ export function handleSubjectShareSold(event: SubjectShareSold): void {
   const blockInfo = getOrCreateBlockInfo(event.block)
   // calculating price here the sell amount will be subject token and buy amount is protocol token since it's a sell
   let subjectToken = getOrCreateSubjectToken(event.params._sellToken, event.block)
-  let price = new CalculatePrice(subjectToken.reserve, subjectToken.totalSupply, subjectToken.reserveRatio)
+  
+  //Since HandleSellOrder is called before the vault transfer we need to predict final state of reserve and supply when calculating price
+  let predictedReserve = subjectToken.reserve.minus(event.params._buyAmount.plus(fees.protocolFee).plus(fees.subjectFee))
+  let predictedTotalSupply = subjectToken.totalSupply.minus(event.params._sellAmount)
+  let price = new CalculatePrice(predictedReserve, predictedTotalSupply, subjectToken.reserveRatio)
   subjectToken.currentPriceInMoxie = price.price
   subjectToken.currentPriceInWeiInMoxie = price.priceInWei
   subjectToken.lifetimeVolume = subjectToken.lifetimeVolume.plus(protocolTokenAmount)

--- a/moxie-protocol/src/moxie-bonding-curve.ts
+++ b/moxie-protocol/src/moxie-bonding-curve.ts
@@ -8,7 +8,7 @@ export function handleBondingCurveInitialized(event: BondingCurveInitialized): v
   let subjectToken = getOrCreateSubjectToken(event.params._subjectToken, event.block)
   subjectToken.reserveRatio = event.params._reserveRatio
   subjectToken.initialSupply = event.params._initialSupply // initial supply of subject token
-  let calculatedPrice = new CalculatePrice(event.params._reserve, event.params._initialSupply)
+  let calculatedPrice = new CalculatePrice(event.params._reserve, subjectToken.initialSupply, subjectToken.reserveRatio)
   subjectToken.currentPriceInMoxie = calculatedPrice.price
   subjectToken.currentPriceInWeiInMoxie = calculatedPrice.priceInWei
   saveSubjectToken(subjectToken, event.block, true)
@@ -49,11 +49,10 @@ export function handleSubjectSharePurchased(event: SubjectSharePurchased): void 
   let protocolTokenSpentAfterFees = event.params._sellAmount.minus(fees.protocolFee).minus(fees.subjectFee)
 
   const blockInfo = getOrCreateBlockInfo(event.block)
-  // calculating price here the sell amount will be in protocol token and buy amount is protocol token since it's a buy
-  let calculatedPrice = new CalculatePrice(protocolTokenSpentAfterFees, event.params._buyAmount)
   // TODO: need to fix for spender
   let user = getOrCreateUser(event.params._beneficiary, event.block)
   let subjectToken = getOrCreateSubjectToken(event.params._buyToken, event.block)
+  let calculatedPrice = new CalculatePrice(subjectToken.reserve, subjectToken.totalSupply, subjectToken.reserveRatio)
   subjectToken.buySideVolume = subjectToken.buySideVolume.plus(event.params._sellAmount)
   subjectToken.protocolTokenInvested = subjectToken.protocolTokenInvested.plus(new BigDecimal(event.params._sellAmount))
   subjectToken.currentPriceInMoxie = calculatedPrice.price
@@ -163,8 +162,8 @@ export function handleSubjectShareSold(event: SubjectShareSold): void {
 
   const blockInfo = getOrCreateBlockInfo(event.block)
   // calculating price here the sell amount will be subject token and buy amount is protocol token since it's a sell
-  let price = new CalculatePrice(protocolTokenAmountReducingFees, event.params._sellAmount)
   let subjectToken = getOrCreateSubjectToken(event.params._sellToken, event.block)
+  let price = new CalculatePrice(subjectToken.reserve, subjectToken.totalSupply, subjectToken.reserveRatio)
   subjectToken.currentPriceInMoxie = price.price
   subjectToken.currentPriceInWeiInMoxie = price.priceInWei
   subjectToken.lifetimeVolume = subjectToken.lifetimeVolume.plus(protocolTokenAmount)

--- a/moxie-protocol/src/utils.ts
+++ b/moxie-protocol/src/utils.ts
@@ -502,6 +502,7 @@ export function decodeOrder(encodedOrderId: Bytes): AuctionOrderClass {
 export class CalculatePrice {
   price: BigDecimal
   priceInWei: BigDecimal
+  //Price = Reserve/TotalSupply * ReserveRatio
   constructor(reserve: BigInt, totalSupply: BigInt, reserveRatio: BigInt) {
     if (reserveRatio.equals(BigInt.zero())) {
       this.price = BigDecimal.zero()

--- a/moxie-protocol/src/utils.ts
+++ b/moxie-protocol/src/utils.ts
@@ -506,12 +506,12 @@ export class CalculatePrice {
     if (reserveRatio.equals(BigInt.zero())) {
       this.price = BigDecimal.zero()
       this.priceInWei = BigDecimal.zero()
-      return
+    } else {
+      //Converting it from 800000 to 0.8
+      let reserveRatioDecimal = reserveRatio.divDecimal(BigInt.fromI32(10).pow(6).toBigDecimal())
+      this.price = reserve.divDecimal(totalSupply.toBigDecimal().times(reserveRatioDecimal))
+      this.priceInWei = this.price.times(BigInt.fromI32(10).pow(18).toBigDecimal())
     }
-    //Converting it from 800000 to 0.8
-    let reserveRatioDecimal = reserveRatio.divDecimal(BigInt.fromI32(10).pow(6).toBigDecimal())
-    this.price = reserve.divDecimal(totalSupply.toBigDecimal().times(reserveRatioDecimal))
-    this.priceInWei = this.price.times(BigInt.fromI32(10).pow(18).toBigDecimal())
   }
 }
  

--- a/moxie-protocol/src/utils.ts
+++ b/moxie-protocol/src/utils.ts
@@ -502,12 +502,19 @@ export function decodeOrder(encodedOrderId: Bytes): AuctionOrderClass {
 export class CalculatePrice {
   price: BigDecimal
   priceInWei: BigDecimal
-  constructor(protocolTokenAmount: BigInt, subjectTokenAmount: BigInt) {
-    this.price = protocolTokenAmount.divDecimal(subjectTokenAmount.toBigDecimal())
+  constructor(reserve: BigInt, totalSupply: BigInt, reserveRatio: BigInt) {
+    if (reserveRatio.equals(BigInt.zero())) {
+      this.price = BigDecimal.zero()
+      this.priceInWei = BigDecimal.zero()
+      return
+    }
+    //Converting it from 800000 to 0.8
+    let reserveRatioDecimal = reserveRatio.divDecimal(BigInt.fromI32(10).pow(6).toBigDecimal())
+    this.price = reserve.divDecimal(totalSupply.toBigDecimal().times(reserveRatioDecimal))
     this.priceInWei = this.price.times(BigInt.fromI32(10).pow(18).toBigDecimal())
   }
 }
-
+ 
 export function loadAuction(auctionId: BigInt): Auction {
   let auction = Auction.load(auctionId.toString())
   if (!auction) {


### PR DESCRIPTION
It was observed that currentPriceInMoxie present in the protocol subgraphs was presenting an inconsistency in relation to the totalSupply of the token. This is due to the approach taking the average price per subject token of the latest and presenting that as the current price. 

However due to the nature of the bonding curves this would not work out with larger trades. 

We have now moved to use the Bancor Formula to get price at a given point in the bonding curve. An explanation can be found [here](https://meissereconomics.com/assets/abfe-lesson5-bancor.pdf). Pricing shall be more sensitive to the total supply of the token rather than the volume of the trade. 