### PR TITLE
added router whitelisting

### DIFF
--- a/moxie-protocol-transactional/src/constants.ts
+++ b/moxie-protocol-transactional/src/constants.ts
@@ -9,3 +9,7 @@ BLACKLISTED_SUBJECT_TOKEN_ADDRESS.set("0x7412b5b7a7498f7b2a663b5c708a98f3092847f
 
 export const BLACKLISTED_AUCTION = new TypedMap<string, bool>()
 BLACKLISTED_AUCTION.set("228", true)
+
+export const WHITELISTED_ROUTERS = new TypedMap<string, bool>()
+// RainbowRouter
+WHITELISTED_ROUTERS.set("0x00000000009726632680fb29d3f7a9734e3010e2", true)

--- a/moxie-protocol-transactional/src/utils.ts
+++ b/moxie-protocol-transactional/src/utils.ts
@@ -1,7 +1,7 @@
 import { Address, BigDecimal, BigInt, ByteArray, Bytes, ethereum, log, store } from "@graphprotocol/graph-ts"
 import { ERC20 } from "../generated/TokenManager/ERC20"
 import { BlockInfo, Portfolio, SubjectToken, User, Summary } from "../generated/schema"
-import { BLACKLISTED_AUCTION, BLACKLISTED_SUBJECT_TOKEN_ADDRESS, PCT_BASE, SUMMARY_ID } from "./constants"
+import { BLACKLISTED_AUCTION, BLACKLISTED_SUBJECT_TOKEN_ADDRESS, PCT_BASE, SUMMARY_ID, WHITELISTED_ROUTERS } from "./constants"
 
 export function getOrCreateSubjectToken(subjectTokenAddress: Address, block: ethereum.Block): SubjectToken {
   let subjectToken = SubjectToken.load(subjectTokenAddress.toHexString())
@@ -205,4 +205,8 @@ export function isBlacklistedSubjectTokenAddress(subjectAddress: Address): bool 
 
 export function isBlacklistedAuction(auctionId: string): bool {
   return BLACKLISTED_AUCTION.isSet(auctionId)
+}
+
+export function isWhiteListedRouter(routerAddress: Address): bool {
+  return WHITELISTED_ROUTERS.isSet(routerAddress.toHexString())
 }

--- a/moxie-protocol/src/constants.ts
+++ b/moxie-protocol/src/constants.ts
@@ -24,3 +24,8 @@ BLACKLISTED_SUBJECT_TOKEN_ADDRESS.set("0x7412b5b7a7498f7b2a663b5c708a98f3092847f
 
 export const BLACKLISTED_AUCTION = new TypedMap<string, bool>()
 BLACKLISTED_AUCTION.set("228", true)
+
+
+export const WHITELISTED_ROUTERS = new TypedMap<string, bool>()
+// RainbowRouter
+WHITELISTED_ROUTERS.set("0x00000000009726632680fb29d3f7a9734e3010e2", true)

--- a/moxie-protocol/src/moxie-bonding-curve.ts
+++ b/moxie-protocol/src/moxie-bonding-curve.ts
@@ -2,7 +2,7 @@ import { BigDecimal, BigInt, log } from "@graphprotocol/graph-ts"
 import { BondingCurveInitialized, SubjectSharePurchased, SubjectShareSold, UpdateBeneficiary, UpdateFees, UpdateFormula, Initialized, MoxieBondingCurve } from "../generated/MoxieBondingCurve/MoxieBondingCurve"
 import { Order, ProtocolFeeBeneficiary, ProtocolFeeTransfer, SubjectFeeTransfer, Summary, User } from "../generated/schema"
 
-import { calculateBuySideFee, calculateSellSideFee, createProtocolFeeTransfer, createSubjectFeeTransfer, getOrCreateBlockInfo, getOrCreatePortfolio, getOrCreateSubjectToken, getOrCreateUser, getTxEntityId, handleNewBeneficiary, getOrCreateSummary, savePortfolio, saveSubjectToken, saveUser, CalculatePrice, calculateSellSideProtocolAmountAddingBackFees, isBlacklistedSubjectTokenAddress } from "./utils"
+import { calculateBuySideFee, calculateSellSideFee, createProtocolFeeTransfer, createSubjectFeeTransfer, getOrCreateBlockInfo, getOrCreatePortfolio, getOrCreateSubjectToken, getOrCreateUser, getTxEntityId, handleNewBeneficiary, getOrCreateSummary, savePortfolio, saveSubjectToken, saveUser, CalculatePrice, calculateSellSideProtocolAmountAddingBackFees, isBlacklistedSubjectTokenAddress, isWhiteListedRouter } from "./utils"
 import { ORDER_TYPE_BUY as BUY, AUCTION_ORDER_CANCELLED as CANCELLED, AUCTION_ORDER_NA as NA, AUCTION_ORDER_PLACED as PLACED, ORDER_TYPE_SELL as SELL, SUMMARY_ID } from "./constants"
 export function handleBondingCurveInitialized(event: BondingCurveInitialized): void {
   if (isBlacklistedSubjectTokenAddress(event.params._subjectToken)) {
@@ -52,11 +52,15 @@ export function handleSubjectSharePurchased(event: SubjectSharePurchased): void 
   // _beneficiary.portfolio.protocolTokenInvested += 0
 
   const fees = calculateBuySideFee(event.params._sellAmount)
-  let protocolTokenSpentAfterFees = event.params._sellAmount.minus(fees.protocolFee).minus(fees.subjectFee)
 
   const blockInfo = getOrCreateBlockInfo(event.block)
   // TODO: need to fix for spender
-  let user = getOrCreateUser(event.params._beneficiary, event.block)
+  let userAddress = event.params._beneficiary
+  if (isWhiteListedRouter(userAddress)) {
+    // when the beneficiary is a router, we need to use the actual user address
+    userAddress = event.transaction.from
+  }
+  let user = getOrCreateUser(userAddress, event.block)
   let subjectToken = getOrCreateSubjectToken(event.params._buyToken, event.block)
   let calculatedPrice = new CalculatePrice(subjectToken.reserve, subjectToken.totalSupply, subjectToken.reserveRatio)
   subjectToken.buySideVolume = subjectToken.buySideVolume.plus(event.params._sellAmount)
@@ -80,7 +84,7 @@ export function handleSubjectSharePurchased(event: SubjectSharePurchased): void 
   order.blockInfo = blockInfo.id
 
   // updating user's portfolio
-  let portfolio = getOrCreatePortfolio(event.params._beneficiary, event.params._buyToken, event.transaction.hash, event.block)
+  let portfolio = getOrCreatePortfolio(userAddress, event.params._buyToken, event.transaction.hash, event.block)
   portfolio.buyVolume = portfolio.buyVolume.plus(event.params._sellAmount)
   portfolio.protocolTokenInvested = portfolio.protocolTokenInvested.plus(new BigDecimal(event.params._sellAmount))
   portfolio.subjectTokenBuyVolume = portfolio.subjectTokenBuyVolume.plus(event.params._buyAmount)
@@ -183,7 +187,12 @@ export function handleSubjectShareSold(event: SubjectShareSold): void {
   if (event.params._spender != event.params._beneficiary) {
     // TODO: need to fix for spender
   }
-  let user = getOrCreateUser(event.params._beneficiary, event.block)
+  let userAddress = event.params._beneficiary
+  if (isWhiteListedRouter(userAddress)) {
+    // when the beneficiary is a router, we need to use the actual user address
+    userAddress = event.transaction.from
+  }
+  let user = getOrCreateUser(userAddress, event.block)
 
   // Saving order entity
   let order = new Order(getTxEntityId(event))
@@ -201,10 +210,10 @@ export function handleSubjectShareSold(event: SubjectShareSold): void {
   order.blockInfo = blockInfo.id
 
   // updating user's portfolio
-  let portfolio = getOrCreatePortfolio(event.params._beneficiary, event.params._sellToken, event.transaction.hash, event.block)
+  let portfolio = getOrCreatePortfolio(userAddress, event.params._sellToken, event.transaction.hash, event.block)
   // volume calculation is using amount+fees
   portfolio.sellVolume = portfolio.sellVolume.plus(protocolTokenAmount)
-  
+
   // buyVolume / subjectTokenBuyVolume = protocolTokenInvested / balance
   if (portfolio.subjectTokenBuyVolume.gt(BigInt.zero())) {
     let oldPortfolioProtocolTokenInvested = portfolio.protocolTokenInvested

--- a/moxie-protocol/src/moxie-bonding-curve.ts
+++ b/moxie-protocol/src/moxie-bonding-curve.ts
@@ -98,6 +98,7 @@ export function handleSubjectSharePurchased(event: SubjectSharePurchased): void 
   user.buyVolume = user.buyVolume.plus(event.params._sellAmount)
   // increasing user investment
   user.protocolTokenInvested = user.protocolTokenInvested.plus(new BigDecimal(event.params._sellAmount))
+  user.protocolOrdersCount = user.protocolOrdersCount.plus(BigInt.fromI32(1))
   saveUser(user, event.block)
 
   const summary = getOrCreateSummary()
@@ -245,6 +246,7 @@ export function handleSubjectShareSold(event: SubjectShareSold): void {
   summary.totalProtocolFee = summary.totalProtocolFee.plus(fees.protocolFee)
   summary.totalSubjectFee = summary.totalSubjectFee.plus(fees.subjectFee)
   summary.save()
+  user.protocolOrdersCount = user.protocolOrdersCount.plus(BigInt.fromI32(1))
   saveUser(user, event.block)
   savePortfolio(portfolio, event.block)
   createProtocolFeeTransfer(event, blockInfo, order, subjectToken, activeFeeBeneficiary, fees.protocolFee)

--- a/moxie-protocol/src/utils.ts
+++ b/moxie-protocol/src/utils.ts
@@ -1,7 +1,7 @@
 import { Address, BigDecimal, BigInt, Bytes, ethereum, log, store, ByteArray } from "@graphprotocol/graph-ts"
 import { ERC20 } from "../generated/TokenManager/ERC20"
 import { BlockInfo, Order, Portfolio, ProtocolFeeBeneficiary, ProtocolFeeTransfer, SubjectToken, SubjectTokenDailySnapshot, SubjectFeeTransfer, SubjectTokenHourlySnapshot, Summary, User, SubjectTokenRollingDailySnapshot, Auction } from "../generated/schema"
-import { BLACKLISTED_AUCTION, BLACKLISTED_SUBJECT_TOKEN_ADDRESS, ONBOARDING_STATUS_ONBOARDING_INITIALIZED, PCT_BASE, SECONDS_IN_DAY, SECONDS_IN_HOUR, SUMMARY_ID, TOKEN_DECIMALS } from "./constants"
+import { BLACKLISTED_AUCTION, BLACKLISTED_SUBJECT_TOKEN_ADDRESS, ONBOARDING_STATUS_ONBOARDING_INITIALIZED, PCT_BASE, SECONDS_IN_DAY, SECONDS_IN_HOUR, SUMMARY_ID, TOKEN_DECIMALS, WHITELISTED_ROUTERS } from "./constants"
 
 export function getOrCreateSubjectToken(subjectTokenAddress: Address, block: ethereum.Block): SubjectToken {
   let subjectToken = SubjectToken.load(subjectTokenAddress.toHexString())
@@ -530,4 +530,8 @@ export function isBlacklistedSubjectTokenAddress(subjectAddress: Address): bool 
 
 export function isBlacklistedAuction(auctionId: string): bool {
   return BLACKLISTED_AUCTION.isSet(auctionId)
+}
+
+export function isWhiteListedRouter(routerAddress: Address): bool {
+  return WHITELISTED_ROUTERS.isSet(routerAddress.toHexString())
 }


### PR DESCRIPTION
- handles transactions where white listed middle contract/router is involved
- during similar cases, we use the transaction caller as user 
[https://basescan.org/tx/0xcc41681244ee3435e1e529bad1100feab0391d48ef7a61612cfd4fed16f18f8e](https://basescan.org/tx/0xcc41681244ee3435e1e529bad1100feab0391d48ef7a61612cfd4fed16f18f8e)
<img width="820" alt="Screenshot 2024-08-30 at 6 49 19 PM" src="https://github.com/user-attachments/assets/9da544bf-8bd9-4262-9888-f1953ef154bc">
